### PR TITLE
FOCUS SESSION TRACKER

### DIFF
--- a/#950_FOCUS_SESSION_TRACKER/FOCUS_SESSION_TRACKER.py
+++ b/#950_FOCUS_SESSION_TRACKER/FOCUS_SESSION_TRACKER.py
@@ -1,0 +1,68 @@
+import sys
+import time
+from datetime import timedelta
+
+def run_timer(minutes, label):
+    total_seconds = int(minutes * 60)
+    
+    try:
+        for s in reversed(range(total_seconds)):
+            mins, secs = divmod(s, 60)
+            timer_display = f'{label}: {mins:02d}:{secs:02d}'
+            
+            sys.stdout.write(f'\r{timer_display} ')
+            sys.stdout.flush()
+            
+            time.sleep(1)
+            
+        sys.stdout.write(f'\r{" " * 30}\r')
+        print(f"{label} session complete.")
+        return True
+        
+    except KeyboardInterrupt:
+        print("\n\nTimer cancelled by user.")
+        return False
+
+def main():
+    total_productive_seconds = 0
+    print("--- Focus & Break Timer ---")
+    
+    while True:
+        action = input("\nAction? (f)ocus, (b)reak, (q)uit: ").lower().strip()
+        
+        if action == 'q':
+            break
+            
+        elif action in ['f', 'b']:
+            label = "Focus" if action == 'f' else "Break"
+            
+            try:
+                duration_str = input(f"Enter duration for {label} (minutes): ")
+                duration_minutes = float(duration_str)
+                
+                if duration_minutes <= 0:
+                    print("Error: Please enter a positive number for minutes.")
+                    continue
+                    
+            except ValueError:
+                print("Error: Invalid input. Please enter a numerical value.")
+                continue
+
+            completed = run_timer(duration_minutes, label)
+            
+            if completed and action == 'f':
+                total_productive_seconds += duration_minutes * 60
+                
+        else:
+            print("Invalid action. Please choose 'f', 'b', or 'q'.")
+
+    print("\n--------------------------")
+    if total_productive_seconds > 0:
+        formatted_time = str(timedelta(seconds=int(total_productive_seconds)))
+        print(f"Total Productive Time: {formatted_time}")
+    else:
+        print("No productive time was tracked.")
+    print("Goodbye.")
+    
+if __name__ == "__main__":
+    main()

--- a/#950_FOCUS_SESSION_TRACKER/README.md
+++ b/#950_FOCUS_SESSION_TRACKER/README.md
@@ -1,0 +1,55 @@
+# 🕰️ Focus Timer CLI
+
+A simple, zero-dependency terminal timer to help you focus.
+
+---
+
+### What is this?
+
+This is a lightweight Python script that runs in your terminal. It helps you track work sessions and breaks, showing you how much productive time you've logged when you're done. No distractions, no fancy UI, just pure focus.
+
+### Core Features
+
+* ** Focus Mode**: Set a timer for deep work.
+* ** Break Mode**: Set a timer for a quick break.
+* ** Time Summary**: Shows your total focused time at the end.
+* ** Keyboard Control**: Simple `f`, `b`, `q` commands.
+* ** No Installation**: Just needs Python 3.
+
+---
+
+### Get Started
+
+1.  **Save the Code**: Save the script on your computer as `focus.py`.
+
+2.  **Run it from your terminal**:
+    ```sh
+    python3 focus.py
+    ```
+
+---
+
+### How It Works
+
+The interface is minimal. You're asked for an action, then the time in minutes.
+
+> ```
+> --- Focus & Break Timer ---
+>
+> Action? (f)ocus, (b)reak, (q)uit: f
+> Enter duration for Focus (minutes): 25
+> Focus: 24:59 
+> ```
+>
+> When the timer finishes, it will ask for your next action. When you're ready to finish your work session:
+>
+> ```
+> Action? (f)ocus, (b)reak, (q)uit: q
+>
+> --------------------------
+> Total Productive Time: 0:25:00
+> Goodbye.
+> ```
+
+---
+*License: MIT*


### PR DESCRIPTION
Added a new, minimalist command-line script (`focus_timer.py`) for tracking focus sessions and breaks.

**Key Changes:**

* **Functionality**: Users can start focus (`f`) or break (`b`) timers.
* **Productivity Summary**: On exit (`q`), the script displays the total focused time.
* **User Experience**: A clean, single-line countdown timer that handles `Ctrl+C` for cancellation.
* **Dependencies**: Zero external dependencies, runs with standard Python 3.

**How to Verify:**

1.  Run the script: `python3 focus_timer.py`
2.  Use `f` to start a focus session and let it complete.
3.  Use `b` to start a break session.
4.  Use `q` to exit and confirm the total productive time is displayed correctly.
<img width="454" height="99" alt="image" src="https://github.com/user-attachments/assets/847d3d59-0ee6-42c2-a314-fd2905414e9c" />

<img width="452" height="96" alt="image" src="https://github.com/user-attachments/assets/c2b5ae9d-dcb6-4854-bb02-c0546d118f5b" />

fixes https://github.com/sumanth-0/100LinesOfPythonCode/issues/950
