### PR TITLE
feat(gui): Implement desktop notifications using plyer after each work/break session(#944)

### DIFF
--- a/Pomodoro_Timer/pomodoro_timer.py
+++ b/Pomodoro_Timer/pomodoro_timer.py
@@ -1,5 +1,6 @@
 import tkinter as tk
 import time
+from plyer import notification 
 
 # Pomodoro Settings
 WORK_MIN = 25
@@ -74,10 +75,27 @@ class PomodoroTimer:
         self.label.config(text=f"{self.timer_type} Time")
 
     def notify(self):
+        # Determine the message and title based on the session that just finished
         if self.timer_type == "Break":
+            # If the new session is a 'Break', the Work session just finished.
+            title = "Work Session Complete!"
+            message = "Time for a well-deserved break! Take 5 minutes to rest."
             print("Time for a break!")
         else:
+            # If the new session is 'Work', the Break session just finished.
+            title = "Break is Over!"
+            message = "Time to focus. Get back to work!"
             print("Time to get back to work!")
+            
+        # Send the desktop notification
+        notification.notify(
+            title=title,
+            message=message,
+            app_name='Pomodoro Timer',
+            timeout=10 # Notification disappears after 10 seconds
+        )   
+
+
 
 # Run the Pomodoro Timer
 root = tk.Tk()


### PR DESCRIPTION
###  Fixes #944 
This PR implements desktop notifications to alert the user when a work or break session concludes, addressing the request for a timer that notifies the user after each session.

### Type of change
- [ ] Bug fix 
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change 
- [ ] Documentation update

### Description and Changes Made
- Added the `plyer` library dependency for cross-platform desktop notifications.
- Integrated the notification logic into the main timer loop function.
- Updated the existing notify() method within pomodoro_timer.py to use plyer
- Sends a notification (e.g., "Work Session Over!") when the timer hits zero for both work and break sessions.

### Tests performed (required)
Tested on [ Windows 11] with Python [3.10] and verified that system notifications appear correctly when the timer finishes.

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [ ] I have added tests that prove my fix is effective or that my feature works *(Can be unchecked if no formal tests exist)*
- [x] I have added documentation wherever appropriate
