### PR TITLE
feat(art): Add script for generating typographic art patterns (#940)

### DIFF
--- a/TYPOGRAPHIC_ART/typographic.py
+++ b/TYPOGRAPHIC_ART/typographic.py
@@ -1,0 +1,37 @@
+import random
+
+def create_stylized_art(text, symbol="*"):
+    """
+    Converts input text into a stylized pattern using repeated letters 
+    or symbols.
+    """
+    art_output = []
+    text = text.upper() # Use uppercase for consistent block art
+
+    for char in text:
+        # 1. Base pattern (using the character itself)
+        char_pattern = f"{char * 3} {char} {char * 3}"
+        
+        # 2. Border/Styling pattern (using the chosen symbol)
+        # Randomly choose a styling option for variety
+        style_choice = random.randint(1, 3)
+        
+        if style_choice == 1:
+            line = f"{symbol*2} {char_pattern} {symbol*2}"
+        elif style_choice == 2:
+            line = f"<{char_pattern}>"
+        else:
+            line = f"|{char}| {char_pattern} |{char}|"
+            
+        art_output.append(line)
+        
+    return "\n".join(art_output)
+
+# Example Usage
+if __name__ == "__main__":
+    user_text = input("Enter text to stylize: ")
+    
+    # Simple output
+    print("\n--- Stylized Output ---")
+    print(create_stylized_art(user_text, symbol="#"))
+    print("-----------------------\n")


### PR DESCRIPTION
### Fixes #940**

This PR adds a new script for "Typographic Art," fulfilling the request to convert text into a stylized pattern using repeated letters or symbols. This provides a pure Python example of string manipulation for artistic output.

### Type of change
- [ ] Bug fix 
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change 
- [ ] Documentation update 

### Description and Changes Made
- Created a new directory, `TYPOGRAPHIC_ART`, to house the script.
- Added `typographic_art.py`, which contains a function `create_stylized_art()` that accepts a string input.
- The function uses basic Python loops and string repetition to generate patterned output based on the input text.
- Includes example usage in the `if __name__ == "__main__":` block for running the script from the command line.

### Tests performed (required)
Tested on [ Windows 11] with Python [3.10] and verified that different text inputs successfully generate the stylized pattern in the terminal output.

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [ ] I have added tests that prove my fix is effective or that my feature works *(Can be unchecked if no formal tests exist)*
- [x] I have added documentation wherever appropriate

