### PR TITLE
Add case-insensitive conflict checker utility

### DIFF
--- a/Case_Insensitive_Conflict_Checker/README.md
+++ b/Case_Insensitive_Conflict_Checker/README.md
@@ -1,0 +1,39 @@
+# Case-Insensitive Conflict Checker
+
+## Description
+Cloning this repository on Windows or default macOS can fail when two files only differ in their letter casing. This tool scans a project directory and reports every location where case-insensitive filesystems would treat multiple entries as the same path.
+
+## Features
+- Detects collisions between files and folders that differ only by case.
+- Traverses the tree recursively from any starting directory.
+- Optional flag to include hidden entries such as `.gitignore`.
+- Prints a concise report so collisions can be fixed quickly.
+
+## Requirements
+- Python 3.8 or newer.
+
+## Usage
+```bash
+python Case_Insensitive_Conflict_Checker/case_insensitive_conflict_checker.py
+```
+
+### Scan another directory
+```bash
+python Case_Insensitive_Conflict_Checker/case_insensitive_conflict_checker.py path/to/project
+```
+
+### Include hidden files
+```bash
+python Case_Insensitive_Conflict_Checker/case_insensitive_conflict_checker.py --include-hidden
+```
+
+## Example Output
+```
+Conflicts found under C:\path\to\repo (case-insensitive check):
+[scripts]
+  - Readme.md, README.md
+[tools]
+  - helper.py, Helper.py
+```
+
+Use the report to rename or consolidate the listed entries so the project works on every platform.

--- a/Case_Insensitive_Conflict_Checker/case_insensitive_conflict_checker.py
+++ b/Case_Insensitive_Conflict_Checker/case_insensitive_conflict_checker.py
@@ -1,0 +1,99 @@
+"""
+Scan a project for file or directory names that collide on a
+case-insensitive filesystem (e.g., Windows, macOS with default settings).
+
+This helps contributors avoid clone errors by highlighting locations where
+multiple entries differ only by letter casing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, Iterable, List, Sequence, Tuple
+
+
+Collision = Tuple[Path, Sequence[Sequence[str]]]
+
+
+def list_entries(
+    names: Iterable[str],
+    include_hidden: bool,
+) -> List[str]:
+    """Return names filtered according to the hidden flag."""
+    if include_hidden:
+        return list(names)
+    return [name for name in names if not name.startswith(".")]
+
+
+def collect_collisions(root: Path, include_hidden: bool) -> List[Collision]:
+    """Walk the tree under root and gather case-insensitive collisions."""
+    collisions: List[Collision] = []
+
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = list_entries(dirnames, include_hidden)
+        visible_files = list_entries(filenames, include_hidden)
+
+        grouped: Dict[str, List[str]] = defaultdict(list)
+        for name in (*dirnames, *visible_files):
+            grouped[name.casefold()].append(name)
+
+        duplicates = [tuple(sorted(names, key=str.casefold)) for names in grouped.values() if len(names) > 1]
+        if duplicates:
+            current = Path(dirpath)
+            relative = current.relative_to(root)
+            collisions.append((relative, duplicates))
+
+    return collisions
+
+
+def format_report(collisions: Sequence[Collision], root: Path) -> str:
+    """Turn the collisions list into a printable report."""
+    lines: List[str] = []
+    for relative, variants in collisions:
+        location = "." if relative == Path(".") else str(relative)
+        lines.append(f"[{location}]")
+        for names in variants:
+            variants_str = ", ".join(names)
+            lines.append(f"  - {variants_str}")
+    if not lines:
+        return f"No case-insensitive conflicts found under {root}"
+    header = f"Conflicts found under {root} (case-insensitive check):"
+    return "\n".join([header, *lines])
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Detect filename collisions that break on case-insensitive filesystems.",
+    )
+    parser.add_argument(
+        "path",
+        nargs="?",
+        default=".",
+        help="Project directory to scan (defaults to current working directory).",
+    )
+    parser.add_argument(
+        "--include-hidden",
+        action="store_true",
+        help="Also report entries that start with a dot.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    root = Path(args.path).resolve()
+
+    if not root.exists():
+        raise SystemExit(f"Path does not exist: {root}")
+    if not root.is_dir():
+        raise SystemExit(f"Path is not a directory: {root}")
+
+    collisions = collect_collisions(root, args.include_hidden)
+    print(format_report(collisions, root))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What was accomplished
- Added new `Case_Insensitive_Conflict_Checker` utility that scans for problematic duplicates.
- Documented how to run the tool and interpret conflicts for contributors facing clone issues.

## Detailed design decisions and rationale
- Normalized names with `str.casefold()` to capture locale-independent collisions.
- Filtered hidden entries by default to match the repository's visible script directories, with an opt-in flag when needed.
- Reported relative paths so the output stays compact while still pointing to the exact location that should be renamed.

## Tests added or modified
- python -m compileall Case_Insensitive_Conflict_Checker
- python Case_Insensitive_Conflict_Checker/case_insensitive_conflict_checker.py

## Alignment with repository patterns and objectives
- Kept the script under 100 lines and provided a companion README consistent with existing project folders.
- Added a self-contained CLI utility that expands the catalog of helpful onboarding scripts for contributors.

Closes #447.
