### PR TITLE
Add simple CLI URL shortener (TinyURL via pyshorteners)

### DIFF
--- a/URL_Shortener/README.md
+++ b/URL_Shortener/README.md
@@ -1,0 +1,37 @@
+Simple URL Shortener
+A simple command-line Python script that shortens a given URL using the TinyURL service.
+
+Description
+This program prompts the user to enter a long URL. It then uses the pyshorteners library to connect to TinyURL, generate a shortened link, and print the result back to the console. The program exits after one successful use.
+
+Features
+Simple, single-use command-line interface.
+
+Uses the reliable TinyURL service.
+
+Includes error handling for invalid URLs or network issues.
+
+Installation
+Clone the repository or download the script.
+
+Install the required Python library: This script depends on the pyshorteners library. You can install it using pip:
+
+Bash
+
+pip install pyshorteners
+Usage
+Run the script from your terminal:
+
+Bash
+
+python your_script_name.py
+(Replace your_script_name.py with the actual name of the file, e.g., shorten.py)
+
+When prompted, paste or type the long URL you want to shorten and press Enter.
+
+Example
+Bash
+
+$ python shorten.py
+Enter the URL to shorten: https://www.example-long-domain-name.com/a-very-long-path/page.html
+Shortened URL: https://tinyurl.com/a1b2c3d4

--- a/URL_Shortener/URL_Shortener.py
+++ b/URL_Shortener/URL_Shortener.py
@@ -1,0 +1,26 @@
+import pyshorteners
+import sys
+
+def shorten_url(url):
+    try:
+        s = pyshorteners.Shortener()
+        short_url = s.tinyurl.short(url)
+        return short_url
+    except Exception as e:
+        print(f"Error: Could not shorten URL. Details: {e}", file=sys.stderr)
+        return None
+
+def main():
+    long_url = input("Enter the URL to shorten: ")
+
+    if not long_url.strip():
+        print("Error: No URL provided.", file=sys.stderr)
+        sys.exit(1)
+
+    short_url = shorten_url(long_url)
+
+    if short_url:
+        print(f"Shortened URL: {short_url}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
#1335

Add a small command-line script and README for a TinyURL-based URL shortener.

- Adds CLI that prompts for a long URL, shortens it via pyshorteners/TinyURL, and prints result.
- Includes basic error handling for invalid URLs and network failures.
- README updated with install/run instructions and example.
- Lightweight, single-use utility intended for easy contribution and demonstration.

Dependency: pyshorteners (pip install pyshorteners)