### PR TITLE
Add Random Walk Art

### DIFF
--- a/Random_Walk_Art/README.md
+++ b/Random_Walk_Art/README.md
@@ -1,0 +1,36 @@
+\# Random Walk Art 🎨
+
+
+
+A fun Python script that generates unique abstract art using random shapes, colors, and positions with OpenCV.
+
+
+
+\## What it does:
+
+
+
+Each time you run the script, it randomly draws circles, rectangles, lines, and ellipses on a blank canvas; creating a new piece of colorful art every time!
+
+
+
+\## How to run:
+
+
+
+1\. Install dependencies:
+
+&nbsp;  ```bash
+
+&nbsp;  pip install opencv-python numpy
+
+
+
+2\. Run the script:
+
+&nbsp;  python random\_walk\_art.py
+
+
+
+-> If using Google Colab, the code already includes cv2\_imshow() for display.
+

--- a/Random_Walk_Art/random_walk_art.ipynb
+++ b/Random_Walk_Art/random_walk_art.ipynb
@@ -1,0 +1,30 @@
+# Random Walk Art
+
+import cv2 as cv
+from google.colab.patches import cv2_imshow   # for colab
+import numpy as np
+import random
+
+canvas = np.zeros((800, 800, 3), dtype=np.uint8)
+
+for _ in range(random.randint(100, 200)) :
+  color = (random.randint(0, 255), random.randint(0, 255), random.randint(0, 255))
+  x = random.randint(0, 800)
+  y = random.randint(0, 800)
+  centre = (random.randint(0, 800), random.randint(0, 800))
+  radius = random.randint(0, 800)
+  shape = random.choice(["circle", "line", "rectangle", "ellipse"])
+  thickness = random.randint(1, 5)
+
+  if shape == "circle":
+    cv.circle(canvas, centre, radius, color, thickness)
+  elif shape == "rectangle":
+    cv.rectangle(canvas, (x, y), (x, y), color, thickness)
+  elif shape == "ellipse":
+    cv.ellipse(canvas, centre, (radius, radius), random.randint(0, 360), random.randint(0, 360), random.randint(0, 360), color, thickness)
+  elif shape == "line":
+    cv.line(canvas, (x, y), (x, y), color, thickness)
+
+cv2_imshow(canvas)   # for colab
+cv.waitKey(0)
+cv.destroyAllWindows()


### PR DESCRIPTION
A Python script `random_walk_art.py` that generates abstract random art using OpenCV. Adds a short README explaining how to run the script. 
Sample output images:

![WhatsApp Image 2025-10-26 at 18 36 05_d5599f92](https://github.com/user-attachments/assets/806b2a10-96e3-4997-ba49-7bffd443914f)

![WhatsApp Image 2025-10-26 at 18 28 48_ebf2d4e2](https://github.com/user-attachments/assets/5a86a34e-dcab-450d-bd72-42b7e30fc952)

Closes https://github.com/sumanth-0/100LinesOfPythonCode/issues/1591